### PR TITLE
Add dedicated About page and navigation highlight

### DIFF
--- a/2024/07/15/Tanngent-first-blog/index.html
+++ b/2024/07/15/Tanngent-first-blog/index.html
@@ -55,11 +55,13 @@
     <div id="header-inner" class="inner">
       <nav id="main-nav">
         <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
-        
+
           <a class="main-nav-link" href="/">Home</a>
-        
+
           <a class="main-nav-link" href="/archives">Archives</a>
-        
+
+          <a class="main-nav-link" href="/about/">About</a>
+
       </nav>
       <nav id="sub-nav">
         
@@ -198,11 +200,13 @@
 
     </div>
     <nav id="mobile-nav">
-  
+
     <a href="/" class="mobile-nav-link">Home</a>
-  
+
     <a href="/archives" class="mobile-nav-link">Archives</a>
-  
+
+    <a href="/about/" class="mobile-nav-link">About</a>
+
 </nav>
     
 

--- a/2024/07/15/hello-world/index.html
+++ b/2024/07/15/hello-world/index.html
@@ -55,11 +55,13 @@
     <div id="header-inner" class="inner">
       <nav id="main-nav">
         <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
-        
+
           <a class="main-nav-link" href="/">Home</a>
-        
+
           <a class="main-nav-link" href="/archives">Archives</a>
-        
+
+          <a class="main-nav-link" href="/about/">About</a>
+
       </nav>
       <nav id="sub-nav">
         
@@ -212,11 +214,13 @@
 
     </div>
     <nav id="mobile-nav">
-  
+
     <a href="/" class="mobile-nav-link">Home</a>
-  
+
     <a href="/archives" class="mobile-nav-link">Archives</a>
-  
+
+    <a href="/about/" class="mobile-nav-link">About</a>
+
 </nav>
     
 

--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+
+
+  <title>About | Tanngent&#39;s Blog</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="了解 Tanngent 的个人背景、技能、项目经历与联系方式。">
+<meta property="og:type" content="profile">
+<meta property="og:title" content="About Tanngent">
+<meta property="og:url" content="http://example.com/about/index.html">
+<meta property="og:site_name" content="Tanngent&#39;s Blog">
+<meta property="og:description" content="了解 Tanngent 的个人背景、技能、项目经历与联系方式。">
+<meta property="og:locale" content="zh_CN">
+<meta property="article:author" content="Tanngent">
+<meta name="twitter:card" content="summary">
+
+    <link rel="alternate" href="/atom.xml" title="Tanngent's Blog" type="application/atom+xml">
+
+
+    <link rel="shortcut icon" href="/favicon.png">
+
+
+
+<link rel="stylesheet" href="/css/style.css">
+
+
+
+<link rel="stylesheet" href="/fancybox/jquery.fancybox.min.css">
+
+
+
+<meta name="generator" content="Hexo 7.3.0"></head>
+
+<body>
+  <div id="container">
+    <div id="wrap">
+      <header id="header">
+  <div id="banner"></div>
+  <div id="header-outer" class="outer">
+    <div id="header-title" class="inner">
+      <h1 id="logo-wrap">
+        <a href="/" id="logo">Tanngent&#39;s Blog</a>
+      </h1>
+
+        <h2 id="subtitle-wrap">
+          <a href="/" id="subtitle">Shanghaitech University</a>
+        </h2>
+
+    </div>
+    <div id="header-inner" class="inner">
+      <nav id="main-nav">
+        <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
+
+          <a class="main-nav-link" href="/">Home</a>
+
+          <a class="main-nav-link" href="/archives">Archives</a>
+
+          <a class="main-nav-link current" href="/about/">About</a>
+
+      </nav>
+      <nav id="sub-nav">
+
+
+          <a class="nav-icon" href="/atom.xml" title="RSS Feed"><span class="fa fa-rss"></span></a>
+
+        <a class="nav-icon nav-search-btn" title="Search"><span class="fa fa-search"></span></a>
+      </nav>
+      <div id="search-form-wrap">
+        <form action="//google.com/search" method="get" accept-charset="UTF-8" class="search-form"><input type="search" name="q" class="search-form-input" placeholder="Search"><button type="submit" class="search-form-submit">&#xF002;</button><input type="hidden" name="sitesearch" value="http://example.com"></form>
+      </div>
+    </div>
+  </div>
+</header>
+
+      <div class="outer">
+        <section id="main"><article id="page-about" class="h-entry article article-type-page about-page" itemscope itemtype="https://schema.org/AboutPage">
+  <div class="article-inner">
+
+
+      <header class="article-header">
+
+
+    <h1 class="p-name article-title" itemprop="headline">
+      关于我
+    </h1>
+
+      <p class="about-tagline">坚持好奇、持续实践，努力成为一名扎实的开发者。</p>
+
+      </header>
+
+    <div class="e-content article-entry about-content" itemprop="mainContentOfPage">
+
+        <section class="about-hero">
+          <div class="about-hero-text">
+            <span class="about-label">你好，我是</span>
+            <h2 class="about-name">Tanngent</h2>
+            <p class="about-summary">上海科技大学在读学生 / 技术爱好者，喜欢把灵感转化为能够解决问题的产品与工具。</p>
+            <div class="about-meta">
+              <span class="about-meta-item"><span class="fa fa-map-marker"></span> 上海，中国</span>
+              <span class="about-meta-item"><span class="fa fa-graduation-cap"></span> Shanghaitech University</span>
+              <span class="about-meta-item"><span class="fa fa-code"></span> 专注 Web · 算法 · 数据分析</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="about-section">
+          <h2>个人简介</h2>
+          <p>我热衷于通过编程探索新事物，喜欢把抽象的想法落实到可以交付的产品上。从课程学习到个人项目，再到参与开源社区，我不断打磨自己的工程能力，也在实践中积累对用户体验的敏感度。</p>
+          <p>在学习之余，我会整理知识、撰写博客，记录问题的解决过程以及值得分享的技术要点，希望自己的经验也能帮助到其他同学。</p>
+        </section>
+
+        <section class="about-section">
+          <h2>技能特长</h2>
+          <ul class="about-skill-list">
+            <li><strong>前端开发：</strong>熟悉现代 HTML / CSS / JavaScript，能够独立完成响应式页面与交互设计。</li>
+            <li><strong>算法竞赛：</strong>掌握常见数据结构与算法范式，关注代码的性能与可靠性。</li>
+            <li><strong>数据分析：</strong>了解 Python 数据分析流程，能够利用可视化工具表达数据价值。</li>
+            <li><strong>工程协作：</strong>善于使用 Git 进行版本管理，重视清晰的文档与代码风格。</li>
+          </ul>
+        </section>
+
+        <section class="about-section">
+          <h2>项目经历</h2>
+          <ol class="about-timeline">
+            <li>
+              <h3>2024 · 个人博客平台</h3>
+              <p>基于 Hexo 搭建的静态博客，关注写作体验、主题定制与部署流程，逐步完善内容体系。</p>
+            </li>
+            <li>
+              <h3>2023 · 校园活动小程序</h3>
+              <p>负责前端界面与交互，实现报名、通知推送、活动数据统计等功能，提升社团活动效率。</p>
+            </li>
+            <li>
+              <h3>2022 · 算法学习打卡</h3>
+              <p>与团队共同维护刷题打卡系统，通过排行榜与提醒机制帮助同学保持学习节奏。</p>
+            </li>
+          </ol>
+        </section>
+
+        <section class="about-section">
+          <h2>联系方式</h2>
+          <div class="about-contact">
+            <div class="about-contact-card">
+              <h3><span class="fa fa-envelope"></span> 邮箱</h3>
+              <p>欢迎通过 <a href="mailto:tanngent@example.com">tanngent@example.com</a> 与我交流课程、项目或实习机会。</p>
+            </div>
+            <div class="about-contact-card">
+              <h3><span class="fa fa-github"></span> GitHub</h3>
+              <p><a href="https://github.com/Tanngent2005" target="_blank" rel="noopener">Tanngent2005</a>，记录代码实践与开源学习。</p>
+            </div>
+            <div class="about-contact-card">
+              <h3><span class="fa fa-pencil"></span> 博客</h3>
+              <p>继续在本站分享学习总结与项目心得，欢迎收藏并留言交流。</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="about-section about-cta">
+          <h2>下一步计划</h2>
+          <p>正在筹备更多与算法、工具开发相关的系列文章，也会尝试把课程项目开源分享。如果你有值得合作或讨论的话题，欢迎随时联系我！</p>
+          <a class="about-cta-button" href="/archives">查看最新文章</a>
+        </section>
+
+    </div>
+
+  </div>
+</article>
+
+
+</section>
+
+          <aside id="sidebar">
+
+
+
+
+  <div class="widget-wrap">
+    <h3 class="widget-title">Tags</h3>
+    <div class="widget">
+      <ul class="tag-list" itemprop="keywords"><li class="tag-list-item"><a class="tag-list-link" href="/tags/DT/" rel="tag">DT</a></li></ul>
+    </div>
+  </div>
+
+
+
+
+  <div class="widget-wrap">
+    <h3 class="widget-title">Tag Cloud</h3>
+    <div class="widget tagcloud">
+      <a href="/tags/DT/" style="font-size: 10px;">DT</a>
+    </div>
+  </div>
+
+
+
+  <div class="widget-wrap">
+    <h3 class="widget-title">Archives</h3>
+    <div class="widget">
+      <ul class="archive-list"><li class="archive-list-item"><a class="archive-list-link" href="/archives/2024/07/">July 2024</a></li></ul>
+    </div>
+  </div>
+
+
+
+
+  <div class="widget-wrap">
+    <h3 class="widget-title">Recent Posts</h3>
+    <div class="widget">
+      <ul>
+
+          <li>
+            <a href="/2024/07/15/Tanngent-first-blog/">Tanngent-first-blog</a>
+          </li>
+
+          <li>
+            <a href="/2024/07/15/hello-world/">Hello World</a>
+          </li>
+
+      </ul>
+    </div>
+  </div>
+
+
+</aside>
+
+      </div>
+      <footer id="footer">
+
+  <div class="outer">
+    <div id="footer-info" class="inner">
+
+      &copy; 2024 Butterfly<br>
+      Powered by <a href="https://hexo.io/" target="_blank">Hexo</a>
+    </div>
+  </div>
+</footer>
+
+    </div>
+    <nav id="mobile-nav">
+
+    <a href="/" class="mobile-nav-link">Home</a>
+
+    <a href="/archives" class="mobile-nav-link">Archives</a>
+
+    <a href="/about/" class="mobile-nav-link current">About</a>
+
+</nav>
+
+
+
+<script src="/js/jquery-3.6.4.min.js"></script>
+
+
+
+
+<script src="/fancybox/jquery.fancybox.min.js"></script>
+
+
+
+
+<script src="/js/script.js"></script>
+
+
+
+
+  </div>
+</body>
+</html>

--- a/archives/2024/07/index.html
+++ b/archives/2024/07/index.html
@@ -53,11 +53,13 @@
     <div id="header-inner" class="inner">
       <nav id="main-nav">
         <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
-        
+
           <a class="main-nav-link" href="/">Home</a>
-        
+
           <a class="main-nav-link" href="/archives">Archives</a>
-        
+
+          <a class="main-nav-link" href="/about/">About</a>
+
       </nav>
       <nav id="sub-nav">
         
@@ -199,11 +201,13 @@
 
     </div>
     <nav id="mobile-nav">
-  
+
     <a href="/" class="mobile-nav-link">Home</a>
-  
+
     <a href="/archives" class="mobile-nav-link">Archives</a>
-  
+
+    <a href="/about/" class="mobile-nav-link">About</a>
+
 </nav>
     
 

--- a/archives/2024/index.html
+++ b/archives/2024/index.html
@@ -53,11 +53,13 @@
     <div id="header-inner" class="inner">
       <nav id="main-nav">
         <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
-        
+
           <a class="main-nav-link" href="/">Home</a>
-        
+
           <a class="main-nav-link" href="/archives">Archives</a>
-        
+
+          <a class="main-nav-link" href="/about/">About</a>
+
       </nav>
       <nav id="sub-nav">
         
@@ -199,11 +201,13 @@
 
     </div>
     <nav id="mobile-nav">
-  
+
     <a href="/" class="mobile-nav-link">Home</a>
-  
+
     <a href="/archives" class="mobile-nav-link">Archives</a>
-  
+
+    <a href="/about/" class="mobile-nav-link">About</a>
+
 </nav>
     
 

--- a/archives/index.html
+++ b/archives/index.html
@@ -53,11 +53,13 @@
     <div id="header-inner" class="inner">
       <nav id="main-nav">
         <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
-        
+
           <a class="main-nav-link" href="/">Home</a>
-        
+
           <a class="main-nav-link" href="/archives">Archives</a>
-        
+
+          <a class="main-nav-link" href="/about/">About</a>
+
       </nav>
       <nav id="sub-nav">
         
@@ -199,11 +201,13 @@
 
     </div>
     <nav id="mobile-nav">
-  
+
     <a href="/" class="mobile-nav-link">Home</a>
-  
+
     <a href="/archives" class="mobile-nav-link">Archives</a>
-  
+
+    <a href="/about/" class="mobile-nav-link">About</a>
+
 </nav>
     
 

--- a/css/style.css
+++ b/css/style.css
@@ -408,6 +408,11 @@ body {
   font-weight: 300;
   letter-spacing: 1px;
 }
+.main-nav-link.current {
+  opacity: 1;
+  font-weight: 500;
+  border-bottom: 2px solid #fff;
+}
 @media screen and (max-width: 479px) {
   .main-nav-link {
     display: none;
@@ -1258,6 +1263,10 @@ pre .javascript .function {
   .mobile-nav-link:hover {
     color: #fff;
   }
+  .mobile-nav-link.current {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.08);
+  }
 }
 @media screen and (min-width: 768px) {
   #sidebar {
@@ -1343,4 +1352,230 @@ pre .javascript .function {
 .tagcloud a {
   margin-right: 5px;
   display: inline-block;
+}
+
+.about-page .article-inner {
+  padding: 45px 50px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+.about-tagline {
+  margin-top: 10px;
+  color: #666;
+  font-size: 1.05em;
+  font-weight: 300;
+}
+.about-hero {
+  background: linear-gradient(135deg, #258fb8, #4ac5d4);
+  border-radius: 12px;
+  padding: 36px;
+  color: #fff;
+  margin: 35px 0 45px;
+  position: relative;
+  overflow: hidden;
+}
+.about-hero:after {
+  content: "";
+  position: absolute;
+  right: -40px;
+  top: -40px;
+  width: 180px;
+  height: 180px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+}
+.about-label {
+  display: inline-block;
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  font-size: 0.75em;
+  font-weight: 600;
+  opacity: 0.85;
+}
+.about-name {
+  font-size: 2.5em;
+  margin: 10px 0 15px;
+  font-weight: 600;
+}
+.about-summary {
+  font-size: 1.15em;
+  line-height: 1.8;
+  margin: 0 0 20px;
+}
+.about-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  font-size: 0.95em;
+}
+.about-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.about-meta-item .fa {
+  font-size: 1em;
+}
+.about-section {
+  margin-bottom: 45px;
+}
+.about-section h2 {
+  font-size: 1.6em;
+  margin-bottom: 18px;
+  position: relative;
+  padding-left: 18px;
+}
+.about-section h2:before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 8px;
+  width: 6px;
+  height: 22px;
+  background: #258fb8;
+  border-radius: 3px;
+}
+.about-section p {
+  color: #555;
+  line-height: 1.9;
+  margin: 10px 0;
+}
+.about-skill-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px 22px;
+}
+.about-skill-list li {
+  background: #f5f7fa;
+  border-radius: 8px;
+  padding: 16px 20px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  color: #444;
+  line-height: 1.6;
+}
+.about-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 20px;
+  border-left: 3px solid #e1e5ee;
+}
+.about-timeline li {
+  position: relative;
+  margin-bottom: 30px;
+  padding-left: 15px;
+}
+.about-timeline li:before {
+  content: "";
+  position: absolute;
+  left: -25px;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  background: #258fb8;
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px #fff;
+}
+.about-timeline h3 {
+  margin: 0 0 8px;
+  font-size: 1.2em;
+}
+.about-timeline p {
+  margin: 0;
+  color: #555;
+  line-height: 1.7;
+}
+.about-contact {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+.about-contact-card {
+  background: #f7f9fc;
+  border-radius: 10px;
+  padding: 22px 24px;
+  border: 1px solid #e5ebf4;
+  box-shadow: 0 10px 20px rgba(37, 143, 184, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.about-contact-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 28px rgba(37, 143, 184, 0.12);
+}
+.about-contact-card h3 {
+  margin: 0 0 10px;
+  font-size: 1.1em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.about-contact-card p {
+  margin: 0;
+  color: #555;
+  line-height: 1.7;
+}
+.about-contact-card a {
+  color: #258fb8;
+  text-decoration: none;
+}
+.about-contact-card a:hover {
+  text-decoration: underline;
+}
+.about-cta {
+  text-align: center;
+  background: #f1f8fb;
+  border-radius: 12px;
+  padding: 32px 28px;
+  border: 1px solid #e0eef5;
+}
+.about-cta p {
+  max-width: 640px;
+  margin: 0 auto 20px;
+}
+.about-cta-button {
+  display: inline-block;
+  background: #258fb8;
+  color: #fff;
+  padding: 12px 28px;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+.about-cta-button:hover {
+  background: #1f7697;
+  transform: translateY(-1px);
+}
+@media screen and (max-width: 900px) {
+  .about-page .article-inner {
+    padding: 36px 28px;
+  }
+  .about-skill-list {
+    grid-template-columns: 1fr;
+  }
+  .about-contact {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+@media screen and (max-width: 600px) {
+  .about-page .article-inner {
+    padding: 28px 22px;
+  }
+  .about-hero {
+    padding: 28px 22px;
+  }
+  .about-name {
+    font-size: 2em;
+  }
+  .about-meta {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .about-contact {
+    grid-template-columns: 1fr;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -53,11 +53,13 @@
     <div id="header-inner" class="inner">
       <nav id="main-nav">
         <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
-        
+
           <a class="main-nav-link" href="/">Home</a>
-        
+
           <a class="main-nav-link" href="/archives">Archives</a>
-        
+
+          <a class="main-nav-link" href="/about/">About</a>
+
       </nav>
       <nav id="sub-nav">
         
@@ -241,11 +243,13 @@
 
     </div>
     <nav id="mobile-nav">
-  
+
     <a href="/" class="mobile-nav-link">Home</a>
-  
+
     <a href="/archives" class="mobile-nav-link">Archives</a>
-  
+
+    <a href="/about/" class="mobile-nav-link">About</a>
+
 </nav>
     
 

--- a/tags/DT/index.html
+++ b/tags/DT/index.html
@@ -53,11 +53,13 @@
     <div id="header-inner" class="inner">
       <nav id="main-nav">
         <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
-        
+
           <a class="main-nav-link" href="/">Home</a>
-        
+
           <a class="main-nav-link" href="/archives">Archives</a>
-        
+
+          <a class="main-nav-link" href="/about/">About</a>
+
       </nav>
       <nav id="sub-nav">
         
@@ -180,11 +182,13 @@
 
     </div>
     <nav id="mobile-nav">
-  
+
     <a href="/" class="mobile-nav-link">Home</a>
-  
+
     <a href="/archives" class="mobile-nav-link">Archives</a>
-  
+
+    <a href="/about/" class="mobile-nav-link">About</a>
+
 </nav>
     
 


### PR DESCRIPTION
## Summary
- add a fully designed About page introducing the author, skills, projects and contact channels
- link the new page from the main and mobile navigation across the site and highlight the active item
- extend the stylesheet with styles for the About page layout and navigation current state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb813ef6d8832492cd5f492f9678d9